### PR TITLE
fix: index out of range in `cmd/dddserver`

### DIFF
--- a/cmd/dddserver/main.go
+++ b/cmd/dddserver/main.go
@@ -2456,7 +2456,7 @@ func (s *server) ParseCard(ctx context.Context, req *pb.ParseCardRequest) (*pb.P
 			}
 		}
 		presence, _ := r.ActivityDailyPresenceCounter.Decode()
-		activityDailyRecords1[i] = &pb.CardActivityDailyRecord{
+		activityDailyRecords2[i] = &pb.CardActivityDailyRecord{
 			ActivityPreviousRecordLength: uint32(r.ActivityPreviousRecordLength),
 			ActivityRecordLength:         uint32(r.ActivityRecordLength),
 			ActivityRecordDate:           r.ActivityRecordDate.Decode().Unix(),


### PR DESCRIPTION
Hello, this PR fixes a "index out of range" crash while parsing some card files through `cmd/dddserver`.
```
panic: runtime error: index out of range [188] with length 188

goroutine 88 [running]:
main.(*server).ParseCard
        /app/tachoparser/cmd/dddserver/main.go:2459
```