### PR TITLE
fix(dddserver): assign V2 events/faults to V2 slice, not V1

### DIFF
--- a/cmd/dddserver/main.go
+++ b/cmd/dddserver/main.go
@@ -1374,7 +1374,7 @@ func (s *server) ParseVu(ctx context.Context, req *pb.ParseVuRequest) (*pb.Parse
 				Signature: rec.Signature,
 			}
 		}
-		vuEventsAndFaults2[i] = &pb.VuEventsAndFaultsSecondGen{
+		vuEventsAndFaults2V2[i] = &pb.VuEventsAndFaultsSecondGenV2{
 			Verified: r.Verified,
 			VuFaultRecordArray: &pb.VuFaultRecordArray{
 				RecordType:  uint32(r.VuFaultRecordArray.RecordType),


### PR DESCRIPTION
Fixes traconiq/tachoparser#23.

The Gen2v2 loop at `cmd/dddserver/main.go:1234` iterates `v.VuEventsAndFaultsSecondGenV2` but its body at `:1377` wrote to the V1 slice `vuEventsAndFaults2` with V1 type `pb.VuEventsAndFaultsSecondGen`. On Gen2v2 VU files where `len(v.VuEventsAndFaultsSecondGenV2) > len(v.VuEventsAndFaultsSecondGen)`, the assignment panicked:

```
panic: runtime error: index out of range [0] with length 0
cmd/dddserver/main.go:1377
```

Even with equal counts, V1 records were silently overwritten by V2 data that belonged in the V2 slice.

## Fix

Rename the assignment target to `vuEventsAndFaults2V2[i]` with the matching `pb.VuEventsAndFaultsSecondGenV2` type, so the V2 loop populates the V2 slice that the response at main.go:2227 (`VuEventsAndFaults_2_2`) consumes.

The two protobuf types have identical fields, so no field-level changes are needed inside the struct literal.

## Test

`gofmt` clean, `go vet ./cmd/dddserver/...` clean aside from a pre-existing embed-pattern error under `internal/pkg/certificates` that is unrelated to this change.